### PR TITLE
Enable the new options that were added in lgogdownloader 3.13

### DIFF
--- a/GOG.sh
+++ b/GOG.sh
@@ -6,4 +6,4 @@
 #
 #
 
-lgogdownloader --download --include all --ignore-dlc-count --no-platform-detection --platform w+l --language en --save-changelogs --save-serials --xml-directory 'aaaMetadata'
+lgogdownloader --download --include all --ignore-dlc-count --no-platform-detection --platform w+l --language en --save-changelogs --save-serials --save-icon --save-product-json --save-game-details-json --xml-directory 'aaaMetadata'


### PR DESCRIPTION
Waiting on the Arch AUR packages to be updated, should be quick enough https://github.com/FabioLolix/PKGBUILD/pull/24#issuecomment-2138167452

Debian testing and sid already have it


Also waiting a new release which include a fix for https://github.com/Sude-/lgogdownloader/issues/272 (that way I'm not pushing users to a version in which they can't login)


---

Saving icon is a great addition

Getting the json is just a way to have a "fuller" archive